### PR TITLE
Fix for non-captured "virtual" transactions

### DIFF
--- a/includes/classes/observers/class.taxcloudObserver.php
+++ b/includes/classes/observers/class.taxcloudObserver.php
@@ -14,6 +14,11 @@ class taxcloudObserver extends base {
 	}
 	
 	// This method gets called once the order is created in the database. At this point we should call TaxCloud and confirm the order.
+	// UPDATE - Change to the lookups of the delivery_country. Now will pull the customers_country, delivery_country, AND billing_country.
+	//          If there is no delivery address (in the case of virtual goods like gift certificates), use the billing address. 
+	//          If that fails, use the customer's address. If that fails, since some mods remove customer info, use the store info.
+	//          Without a valid non-zero $country_id, the authorize_with_capture call will fail to trigger since it is not known
+	//          if TaxCloud is enabled for this transaction or not.
 	function update(&$callingClass, $notifier, $paramsArray) {
 	 
 		$insert_id = $_SESSION['order_number_created'];
@@ -21,13 +26,30 @@ class taxcloudObserver extends base {
 		// Find out what country the order is being shipped to
 		global $db;
 			
-		$results = $db->Execute("select delivery_country from " . TABLE_ORDERS . "
-                        where orders_id = '" . (int)$insert_id . "'");
+		$order_details = $db->Execute("select c1.countries_id AS delivery_lid, c2.countries_id AS billing_lid, c3.countries_id AS customer_lid
+							FROM " . TABLE_ORDERS . " o
+							LEFT JOIN " . TABLE_COUNTRIES . " c1
+							ON c1.countries_name = o.delivery_country
+							LEFT JOIN " . TABLE_COUNTRIES . " c2
+							ON c2.countries_name = o.billing_country
+							LEFT JOIN " . TABLE_COUNTRIES . " c3
+					        	ON c3.countries_name = o.customers_country							
+							WHERE o.orders_id = " . (int)$insert_id);
+
               
-                $country_id = 0;
-                if ( $results->fields['delivery_country'] == 'United States' ) {
-                	$country_id = 223;
-                }
+		if (is_numeric($order_details->fields['delivery_lid'])) { 
+		// Is the delivery country id from the select query a number? If so, assign it to $country_id
+			$country_id = $order_details->fields['delivery_lid'];
+		} else if (is_numeric($order_details->fields['billing_lid'])) {
+		// The number wasn't a number, it was likely a null value. Instead, assign it to the BILLING address
+			$country_id = $order_details->fields['billing_lid'];
+		} else if (is_numeric($order_details->fields['customer_lid'])) {
+			$country_id = $order_details->fields['customer_lid'];
+		} else if (is_numeric(STORE_COUNTRY)) {
+			$country_id = STORE_COUNTRY; // So we don't have an id for delivery, billing, OR the customer, use the store ID
+		} else {
+			$country_id = 0;
+		}
 		
 	   	$TAXCLOUD_ENABLE = func_taxcloud_is_enabled($country_id); 
 	   	if ($TAXCLOUD_ENABLE=='true') {


### PR DESCRIPTION
This patch is to fix TaxCloud not capturing any "virtual" transactions which included (virtual) Gift Certificates, digital downloads, and other transactions which do not get a delivery address.

This is due to the inner workings of ZenCart not assigning a delivery address for any non-physical items. Rightfully so since delivery addresses aren't captured on checkout. Since there was no delivery address, the $TAXCLOUD_ENABLE check would always fail since there is no delivery address. 

The changes will now tell TaxCloud/ZenCart to pull up an order's country code from the delivery_country, billing_country, and customers_country fields. If the order does not have a delivery_country, the program will look to the billing_country. If the order does not have a billing_country either, go to the customers_country. Since it is possible to not require a customers_country on account creation, the penultimate fall back would be to use the STORE_COUNTRY definition defined in the Configuration > My Store area. If all of that fails, I just assigned a number of 0 like it was in default.